### PR TITLE
Speed up loading of xml data

### DIFF
--- a/BackEnd/Data Access/Tables/ControlTable.vb
+++ b/BackEnd/Data Access/Tables/ControlTable.vb
@@ -49,49 +49,67 @@ Public Class ControlTable
         Dim xmlParentNode As XmlNodeList
         Dim xmlChildNode As XmlNodeList
         Dim xmlChild2Node As XmlNodeList
+
         For i As Integer = 0 To xmlnode.ChildNodes.Count - 1
             If xmlnode.ChildNodes.Item(i).Name = "INVENTORY" Then Continue For
+
             _table.Rows.Add()
+            Dim rowIndex As Integer = _table.Rows.Count - 1
+            _table.Rows(rowIndex).BeginEdit()
+
             xmlParentNode = xmlnode.ChildNodes.Item(i).ChildNodes
             For x As Integer = 0 To xmlParentNode.Count - 1
-                If xmlParentNode.Item(x).Name = "#comment" Then Continue For
-                If xmlParentNode.Item(x).Name = "REORDERDAYSDELAY" OrElse xmlParentNode.Item(x).Name = "CASH" OrElse xmlParentNode.Item(x).Name = "COOLNESS" OrElse xmlParentNode.Item(x).Name = "BASICDEALERFLAGS" Then
-                    xmlChildNode = xmlParentNode.Item(x).ChildNodes
+                Dim xmlElement As XmlNode = xmlParentNode.Item(x)
+                Dim xmlElementName As String = xmlElement.Name
+
+                If xmlElementName = "#comment" Then Continue For
+                If xmlElementName = "REORDERDAYSDELAY" OrElse xmlElementName = "CASH" OrElse xmlElementName = "COOLNESS" OrElse xmlElementName = "BASICDEALERFLAGS" Then
+                    xmlChildNode = xmlElement.ChildNodes
+
                     For y As Integer = 0 To xmlChildNode.Count - 1
-                        If xmlChildNode.Item(y).Name = "#comment" Then Continue For
-                        If xmlChildNode.Item(y).Name = "DAILY" Then
-                            xmlChild2Node = xmlChildNode.Item(y).ChildNodes
+                        Dim xmlChildElement As XmlNode = xmlChildNode.Item(y)
+                        Dim xmlChildName As String = xmlChildElement.Name
+
+                        If xmlChildName = "#comment" Then Continue For
+                        If xmlChildName = "DAILY" Then
+                            xmlChild2Node = xmlChildElement.ChildNodes
+
                             For z As Integer = 0 To xmlChild2Node.Count - 1
-                                If _table.Columns.Contains(xmlChild2Node.Item(z).Name) Then
-                                    If xmlChild2Node.Item(z).Name = "#comment" Then Continue For
-                                    If _table.Columns(xmlChild2Node.Item(z).Name).DataType.Name = "Boolean" Then
-                                        _table.Rows(_table.Rows.Count - 1).Item(xmlChild2Node.Item(z).Name) = IIf(xmlChild2Node.Item(z).InnerText.Trim = 1, True, False)
+                                Dim xmlChild2Element As XmlNode = xmlChild2Node.Item(z)
+                                Dim xmlChild2Name As String = xmlChild2Element.Name
+
+                                If _table.Columns.Contains(xmlChild2Name) Then
+                                    If xmlChild2Name = "#comment" Then Continue For
+                                    If _table.Columns(xmlChild2Name).DataType.Name = "Boolean" Then
+                                        _table.Rows(rowIndex).Item(xmlChild2Name) = IIf(xmlChild2Element.InnerText.Trim = 1, True, False)
                                     Else
-                                        _table.Rows(_table.Rows.Count - 1).Item(xmlChild2Node.Item(z).Name) = xmlChild2Node.Item(z).InnerText.Trim
+                                        _table.Rows(rowIndex).Item(xmlChild2Name) = xmlChild2Element.InnerText.Trim
                                     End If
                                 End If
                             Next
                         Else
-                            If _table.Columns.Contains(xmlChildNode.Item(y).Name) Then
-                                If _table.Columns(xmlChildNode.Item(y).Name).DataType.Name = "Boolean" Then
-                                    _table.Rows(_table.Rows.Count - 1).Item(xmlChildNode.Item(y).Name) = IIf(xmlChildNode.Item(y).InnerText.Trim = 1, True, False)
+                            If _table.Columns.Contains(xmlChildName) Then
+                                If _table.Columns(xmlChildName).DataType.Name = "Boolean" Then
+                                    _table.Rows(rowIndex).Item(xmlChildName) = IIf(xmlChildElement.InnerText.Trim = 1, True, False)
                                 Else
-                                    _table.Rows(_table.Rows.Count - 1).Item(xmlChildNode.Item(y).Name) = xmlChildNode.Item(y).InnerText.Trim
+                                    _table.Rows(rowIndex).Item(xmlChildName) = xmlChildElement.InnerText.Trim
                                 End If
                             End If
                         End If
                     Next
                 Else
-                    If _table.Columns.Contains(xmlParentNode.Item(x).Name) Then
-                        If _table.Columns(xmlParentNode.Item(x).Name).DataType.Name = "Boolean" Then
-                            _table.Rows(_table.Rows.Count - 1).Item(xmlParentNode.Item(x).Name) = IIf(xmlParentNode.Item(x).InnerText.Trim = 1, True, False)
+                    If _table.Columns.Contains(xmlElementName) Then
+                        If _table.Columns(xmlElementName).DataType.Name = "Boolean" Then
+                            _table.Rows(rowIndex).Item(xmlElementName) = IIf(xmlElement.InnerText.Trim = 1, True, False)
                         Else
-                            _table.Rows(_table.Rows.Count - 1).Item(xmlParentNode.Item(x).Name) = xmlParentNode.Item(x).InnerText.Trim
+                            _table.Rows(rowIndex).Item(xmlElementName) = xmlElement.InnerText.Trim
                         End If
                     End If
                 End If
             Next
+            _table.Rows(rowIndex).EndEdit()
         Next
+
         fs.Close()
         fs.Dispose()
     End Sub

--- a/BackEnd/Data Access/Tables/ItemTable.vb
+++ b/BackEnd/Data Access/Tables/ItemTable.vb
@@ -376,14 +376,14 @@ Public Class ItemTable
                         If da < 10 Then
                             If _table.Columns.Contains(xmlElementName & da) Then
                                 _table.Rows(rowIndex).Item(xmlElementName & da) = xmlElement.InnerText.Trim
-                                da = da + 1
+                                da += 1
                             End If
                         End If
                     ElseIf xmlElementName = "AvailableAttachmentPoint" Then
                         If aap < 10 Then
                             If _table.Columns.Contains(xmlElementName & aap) Then
                                 _table.Rows(rowIndex).Item(xmlElementName & aap) = xmlElement.InnerText.Trim
-                                aap = aap + 1
+                                aap += 1
                             End If
                         End If
                     Else

--- a/BackEnd/Data Access/Tables/ItemTable.vb
+++ b/BackEnd/Data Access/Tables/ItemTable.vb
@@ -333,6 +333,7 @@ Public Class ItemTable
         Dim da, aap As Integer
         Dim uicomments As Integer = 0
         Dim fs As New FileStream(filePath, FileMode.Open, FileAccess.Read)
+
         xmldoc.Load(fs)
         xmlnode = xmldoc.GetElementsByTagName("ITEMLIST").Item(0)
         For i = 0 To xmlnode.ChildNodes.Count - 1
@@ -341,54 +342,62 @@ Public Class ItemTable
                 Continue For
             End If
             _table.Rows.Add()
+            Dim rowIndex As Integer = i - uicomments
+            _table.Rows(rowIndex).BeginEdit()
+
             a = 0
             da = 0
             aap = 0
             xmlnode2 = xmlnode.ChildNodes.Item(i).ChildNodes
             For x = 0 To xmlnode2.Count - 1
-                If xmlnode2.Item(x).Name = "#comment" Then Continue For
-                If xmlnode2.Item(x).Name = "STAND_MODIFIERS" OrElse xmlnode2.Item(x).Name = "CROUCH_MODIFIERS" OrElse xmlnode2.Item(x).Name = "PRONE_MODIFIERS" Then
-                    If xmlnode2.Item(x).Name = "STAND_MODIFIERS" Then a = 1
-                    If xmlnode2.Item(x).Name = "CROUCH_MODIFIERS" Then a = 2
-                    If xmlnode2.Item(x).Name = "PRONE_MODIFIERS" Then a = 3
-                    xmlnode3 = xmlnode2.Item(x).ChildNodes
+                Dim xmlElement As XmlNode = xmlnode2.Item(x)
+                Dim xmlElementName As String = xmlElement.Name
+
+                If xmlElementName = "#comment" Then Continue For
+                If xmlElementName = "STAND_MODIFIERS" OrElse xmlElementName = "CROUCH_MODIFIERS" OrElse xmlElementName = "PRONE_MODIFIERS" Then
+                    If xmlElementName = "STAND_MODIFIERS" Then a = 1
+                    If xmlElementName = "CROUCH_MODIFIERS" Then a = 2
+                    If xmlElementName = "PRONE_MODIFIERS" Then a = 3
+
+                    xmlnode3 = xmlElement.ChildNodes
                     For y = 0 To xmlnode3.Count - 1
                         If xmlnode3.Item(y).Name = "#comment" Then Continue For
 
                         If _table.Columns.Contains(xmlnode3.Item(y).Name & a) Then
                             If _table.Columns(xmlnode3.Item(y).Name & a).DataType.Name = "Boolean" Then
-                                _table.Rows(i - uicomments).Item(xmlnode3.Item(y).Name & a) = IIf(xmlnode3.Item(y).InnerText.Trim = 1, True, False)
+                                _table.Rows(rowIndex).Item(xmlnode3.Item(y).Name & a) = IIf(xmlnode3.Item(y).InnerText.Trim = 1, True, False)
                             Else
-                                _table.Rows(i - uicomments).Item(xmlnode3.Item(y).Name & a) = xmlnode3.Item(y).InnerText.Trim
+                                _table.Rows(rowIndex).Item(xmlnode3.Item(y).Name & a) = xmlnode3.Item(y).InnerText.Trim
                             End If
                         End If
                     Next
                 Else
-                    If xmlnode2.Item(x).Name = "DefaultAttachment" Then
+                    If xmlElementName = "DefaultAttachment" Then
                         If da < 10 Then
-                            If _table.Columns.Contains(xmlnode2.Item(x).Name & da) Then
-                                _table.Rows(i - uicomments).Item(xmlnode2.Item(x).Name & da) = xmlnode2.Item(x).InnerText.Trim
+                            If _table.Columns.Contains(xmlElementName & da) Then
+                                _table.Rows(rowIndex).Item(xmlElementName & da) = xmlElement.InnerText.Trim
                                 da = da + 1
                             End If
                         End If
-                    ElseIf xmlnode2.Item(x).Name = "AvailableAttachmentPoint" Then
+                    ElseIf xmlElementName = "AvailableAttachmentPoint" Then
                         If aap < 10 Then
-                            If _table.Columns.Contains(xmlnode2.Item(x).Name & aap) Then
-                                _table.Rows(i - uicomments).Item(xmlnode2.Item(x).Name & aap) = xmlnode2.Item(x).InnerText.Trim
+                            If _table.Columns.Contains(xmlElementName & aap) Then
+                                _table.Rows(rowIndex).Item(xmlElementName & aap) = xmlElement.InnerText.Trim
                                 aap = aap + 1
                             End If
                         End If
                     Else
-                        If _table.Columns.Contains(xmlnode2.Item(x).Name) Then
-                            If _table.Columns(xmlnode2.Item(x).Name).DataType.Name = "Boolean" Then
-                                _table.Rows(i - uicomments).Item(xmlnode2.Item(x).Name) = IIf(xmlnode2.Item(x).InnerText.Trim = 1, True, False)
+                        If _table.Columns.Contains(xmlElementName) Then
+                            If _table.Columns(xmlElementName).DataType.Name = "Boolean" Then
+                                _table.Rows(rowIndex).Item(xmlElementName) = IIf(xmlElement.InnerText.Trim = 1, True, False)
                             Else
-                                _table.Rows(i - uicomments).Item(xmlnode2.Item(x).Name) = xmlnode2.Item(x).InnerText.Trim
+                                _table.Rows(rowIndex).Item(xmlElementName) = xmlElement.InnerText.Trim
                             End If
                         End If
                     End If
                 End If
             Next
+            _table.Rows(rowIndex).EndEdit()
         Next
         fs.Close()
         fs.Dispose()

--- a/BackEnd/Data Access/Tables/ItemTransformationTable.vb
+++ b/BackEnd/Data Access/Tables/ItemTransformationTable.vb
@@ -29,6 +29,7 @@ Public Class ItemTransformationTable
         Dim da As Integer
         Dim uiComments As Integer = 0
         Dim fs As New FileStream(filePath, FileMode.Open, FileAccess.Read)
+
         xmldoc.Load(fs)
         xmlnode = xmldoc.GetElementsByTagName("TRANSFORMATIONS_LIST").Item(0)
         For i = 0 To xmlnode.ChildNodes.Count - 1
@@ -36,20 +37,28 @@ Public Class ItemTransformationTable
                 uiComments = uiComments + 1
                 Continue For
             End If
+
             _table.Rows.Add()
+            Dim rowIndex As Integer = i - uiComments
+            _table.Rows(rowIndex).BeginEdit()
+
             da = 1
             xmlnode2 = xmlnode.ChildNodes.Item(i).ChildNodes
             For x = 0 To xmlnode2.Count - 1
-                If xmlnode2.Item(x).Name = "#comment" Then Continue For
-                If xmlnode2.Item(x).Name = "usResult" Then
+                Dim xmlElement As XmlNode = xmlnode2.Item(x)
+                Dim xmlElementName As String = xmlElement.Name
+
+                If xmlElementName = "#comment" Then Continue For
+                If xmlElementName = "usResult" Then
                     If da < 11 Then
-                        _table.Rows(i - uiComments).Item(xmlnode2.Item(x).Name & da) = xmlnode2.Item(x).InnerText.Trim
+                        _table.Rows(rowIndex).Item(xmlElementName & da) = xmlElement.InnerText.Trim
                         da = da + 1
                     End If
                 Else
-                    _table.Rows(i - uiComments).Item(xmlnode2.Item(x).Name) = xmlnode2.Item(x).InnerText.Trim
+                    _table.Rows(rowIndex).Item(xmlElementName) = xmlElement.InnerText.Trim
                 End If
             Next
+            _table.Rows(rowIndex).EndEdit()
         Next
     End Sub
 

--- a/BackEnd/Data Access/Tables/ItemTransformationTable.vb
+++ b/BackEnd/Data Access/Tables/ItemTransformationTable.vb
@@ -52,7 +52,7 @@ Public Class ItemTransformationTable
                 If xmlElementName = "usResult" Then
                     If da < 11 Then
                         _table.Rows(rowIndex).Item(xmlElementName & da) = xmlElement.InnerText.Trim
-                        da = da + 1
+                        da += 1
                     End If
                 Else
                     _table.Rows(rowIndex).Item(xmlElementName) = xmlElement.InnerText.Trim

--- a/BackEnd/Data Access/Tables/MercStartingGearTable.vb
+++ b/BackEnd/Data Access/Tables/MercStartingGearTable.vb
@@ -53,7 +53,7 @@ Public Class MercStartingGearTable
 
                 If xmlElementName = "#comment" Then Continue For
                 If xmlElementName = "GEARKIT" Then
-                    a = a + 1
+                    a += 1
                     xmlnode3 = xmlElement.ChildNodes
                     For y = 0 To xmlnode3.Count - 1
                         If xmlnode3.Item(y).Name = "#comment" Then Continue For

--- a/BackEnd/Data Access/Tables/MercStartingGearTable.vb
+++ b/BackEnd/Data Access/Tables/MercStartingGearTable.vb
@@ -31,43 +31,54 @@ Public Class MercStartingGearTable
         Dim a As Integer
         Dim uiComments As Integer = 0
         Dim fs As New FileStream(filePath, FileMode.Open, FileAccess.Read)
+
         xmldoc.Load(fs)
         xmlnode = xmldoc.GetElementsByTagName("MERCGEARLIST").Item(0)
+
         For i = 0 To xmlnode.ChildNodes.Count - 1
             If xmlnode.ChildNodes.Item(i).Name = "#comment" Then
                 uiComments = uiComments + 1
                 Continue For
             End If
+
             _table.Rows.Add()
+            Dim rowIndex As Integer = i - uiComments
+            _table.Rows(rowIndex).BeginEdit()
+
             a = 0
             xmlnode2 = xmlnode.ChildNodes.Item(i).ChildNodes
             For x = 0 To xmlnode2.Count - 1
-                If xmlnode2.Item(x).Name = "#comment" Then Continue For
-                If xmlnode2.Item(x).Name = "GEARKIT" Then
+                Dim xmlElement As XmlNode = xmlnode2.Item(x)
+                Dim xmlElementName As String = xmlElement.Name
+
+                If xmlElementName = "#comment" Then Continue For
+                If xmlElementName = "GEARKIT" Then
                     a = a + 1
-                    xmlnode3 = xmlnode2.Item(x).ChildNodes
+                    xmlnode3 = xmlElement.ChildNodes
                     For y = 0 To xmlnode3.Count - 1
                         If xmlnode3.Item(y).Name = "#comment" Then Continue For
 
                         If _table.Columns.Contains(xmlnode3.Item(y).Name & a) Then
                             If _table.Columns(xmlnode3.Item(y).Name & a).DataType.Name = "Boolean" Then
-                                _table.Rows(i - uiComments).Item(xmlnode3.Item(y).Name & a) = IIf(xmlnode3.Item(y).InnerText.Trim = 1, True, False)
+                                _table.Rows(rowIndex).Item(xmlnode3.Item(y).Name & a) = IIf(xmlnode3.Item(y).InnerText.Trim = 1, True, False)
                             Else
-                                _table.Rows(i - uiComments).Item(xmlnode3.Item(y).Name & a) = xmlnode3.Item(y).InnerText.Trim
+                                _table.Rows(rowIndex).Item(xmlnode3.Item(y).Name & a) = xmlnode3.Item(y).InnerText.Trim
                             End If
                         End If
                     Next
                 Else
-                    If _table.Columns.Contains(xmlnode2.Item(x).Name) Then
-                        If _table.Columns(xmlnode2.Item(x).Name).DataType.Name = "Boolean" Then
-                            _table.Rows(i - uiComments).Item(xmlnode2.Item(x).Name) = IIf(xmlnode2.Item(x).InnerText.Trim = 1, True, False)
+                    If _table.Columns.Contains(xmlElementName) Then
+                        If _table.Columns(xmlElementName).DataType.Name = "Boolean" Then
+                            _table.Rows(rowIndex).Item(xmlElementName) = IIf(xmlElement.InnerText.Trim = 1, True, False)
                         Else
-                            _table.Rows(i - uiComments).Item(xmlnode2.Item(x).Name) = xmlnode2.Item(x).InnerText.Trim
+                            _table.Rows(rowIndex).Item(xmlElementName) = xmlElement.InnerText.Trim
                         End If
                     End If
                 End If
             Next
+            _table.Rows(rowIndex).EndEdit()
         Next
+
         fs.Close()
         fs.Dispose()
     End Sub


### PR DESCRIPTION
Wrapping the newly added rows' data modification inside Begin/EndEdit() calls significantly sped up loading of xml data that doesn't use the default Xmlreader. Constraints are checked and enforced after all the loading is done so this shouldn't pose any issues.